### PR TITLE
feat(login): add unattended login page

### DIFF
--- a/login/unattended.html
+++ b/login/unattended.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge; IE=11; Chrome=1" />
+    <meta name="description" content="PlaceOS Progressive Web App">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="manifest" href="unattended_manifest.json">
+    <title>PlaceOS</title>
+    <style>
+        svg circle {
+            transform-origin: center;
+            animation: sk-rotate-simple .8s infinite linear;
+        }
+
+        @keyframes sk-rotate-simple {
+            0% {
+                transform: rotate(0deg);
+            }
+            50% {
+                transform: rotate(180deg);
+            }
+            100% {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); display: flex; align-items: center; flex-direction: column;">
+        <div style="height: 160px; width: 160px">
+            <svg viewBox="0 0 120 120">
+                <circle cx="60" cy="60" r="54" fill="none" stroke="rgba(0,0,0, .87)" stroke-width="12" stroke-dasharray="339.292" stroke-dashoffset="271.5"
+                    stroke-linecap="round" />
+            </svg>
+        </div>
+        <div style="font-size: 40px; margin-top: 1em; font-family: sans-serif">Authenticating...</div>
+        <div style="font-size: 10px; margin-top: 1em; font-family: sans-serif">Page should be bookmarked or added to home screen now.</div>
+    </div>
+    <script>
+        var hash_map = {}; // Store for parameters
+
+        function handleResponse(resp) {
+            console.log(resp);
+            setTimeout(function () {
+                // Login success continue
+                if (hash_map.continue) {
+                    window.location.href = decodeURIComponent(hash_map.continue);
+                } else {
+                    window.location.href = '/';
+                }
+            }, 1000);
+        }
+
+        function handleError(resp) {
+            console.error(resp);
+            setTimeout(function () {
+                // Error occurred return request
+                window.location.reload();
+            }, 3000);
+        }
+
+        function enableRefreshTokens() {
+            if (localStorage) {
+                localStorage.setItem('trusted', 'true');
+            }
+        }
+
+        function enableFixedDevice() {
+            if (localStorage) {
+                localStorage.setItem('fixed_device', 'true');
+            }
+        }
+
+        function login() {
+            console.log('Logging in');
+            this.enableRefreshTokens();
+            this.enableFixedDevice();
+            // Grab search string and remove question mark
+            var search = window.location.search.substr(1);
+            // Split paramter
+            var parts = search.split('&');
+            // Map parameters and values to an object
+            for (let i = 0; i < parts.length; i++) {
+                const param = parts[i].split('=');
+                hash_map[param[0]] = param[1];
+            }
+
+            // Grab masked credentials
+            if (hash_map.u) {
+               parts = atob(hash_map.u).split('&');
+               for (let i = 0; i < parts.length; i++) {
+                    const param = parts[i].split('=');
+                    hash_map[param[0]] = param[1];
+                }
+                hash_map.username = hash_map.u;
+                hash_map.password = hash_map.p;
+            }
+
+            // Check if credentials are present
+            if (hash_map.username && hash_map.password) {
+                var request = new XMLHttpRequest();
+                    // Setup event handlers
+                request.addEventListener("load", handleResponse);
+                request.addEventListener("error", handleError);
+                request.addEventListener("abort", handleError);
+                request.open('POST', '/auth/signin');
+                request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+                    // Make request to auth endpoint
+                request.send('email=' + hash_map.username + '&password=' + hash_map.password);
+            } else {
+                // Return to referer if no credentials
+                if (hash_map.continue) {
+                    window.location.href = decodeURIComponent(hash_map.continue);
+                } else {
+                    window.location.href = '/';
+                }
+            }
+        }
+
+        if (window.addEventListener) {
+            window.addEventListener("DOMContentLoaded", login);
+        } else {
+            login();  // IE 8
+        }
+    </script>
+</body>
+
+</html>

--- a/login/unattended_manifest.json
+++ b/login/unattended_manifest.json
@@ -1,0 +1,14 @@
+{
+    "short_name": "PlaceOS App",
+    "name": "PlaceOS App",
+    "icons": [
+        {
+            "src": "favicon.ico",
+            "sizes": "196x196",
+            "type": "png"
+        }
+    ],
+    "background_color": "#000",
+    "theme_color": "#000",
+    "display": "standalone"
+}


### PR DESCRIPTION
Taken from www-template, only renamed "aca" to "placeos" and moved to login/unattended.html instead of /panel_login.html

Tested working OK with params `?u=<...>&continue=/kiosk/`

Are there any other changes you'd like to make before this becomes an official part of the base web root and is deployed for every instance?
